### PR TITLE
[IES-81] Shopware reports an error in the 2.0 version of the plugin

### DIFF
--- a/src/Test/MediaSubscriberTest.php
+++ b/src/Test/MediaSubscriberTest.php
@@ -28,7 +28,7 @@ class MediaSubscriberTest extends TestCase
 
     public function testCdnUrlCorrectFromConfig(): void
     {
-        $url = $this->systemConfigService->get('ScientiaMobileImageEngineCdn.config', Defaults::SALES_CHANNEL);
+        $url = $this->systemConfigService->get('ScientiaMobileImageEngineCdn.config', null);
 
         static::assertTrue($this->checkUrl($url));
     }


### PR DESCRIPTION
Defaults::SALES_CHANNEL const does not exist anymore, replacing it to null means that the plugin configuration can be used by all Sales Channels